### PR TITLE
Do not redefine memset_s() if present

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,7 @@ AS_IF([test "${enable_libcrypto}" = "detect"],
 AS_IF([test "${enable_libcrypto}" = "yes"],
 	[ PKG_CHECK_MODULES(LIBCRYPTO, [libcrypto >= 1.0.1], AC_DEFINE(ENABLE_LIBCRYPTO)) ])
 
+AC_CHECK_FUNCS([memset_s])
 AM_CONDITIONAL([ENABLE_PCSC], [test "${enable_pcsc}" = "yes"])
 AM_CONDITIONAL([ENABLE_CTAPI], [test "${enable_pcsc}" != "yes"])
 AM_CONDITIONAL([ENABLE_RAM], [test "${enable_ram}" = "yes"])

--- a/src/common/memset_s.h
+++ b/src/common/memset_s.h
@@ -13,7 +13,7 @@
  * @ingroup FEPKCS11
  */
 
-#ifndef __APPLE__
+#if !defined(HAVE_MEMSET_S)
 
 #ifdef _WIN32
 static _inline void *memset_s(void *v, size_t vmax, int c, size_t n)

--- a/src/tests/sc-hsm-pkcs11-test.c
+++ b/src/tests/sc-hsm-pkcs11-test.c
@@ -31,6 +31,7 @@
  * @brief Unit test for PKCS#11 interface
  */
 
+#define _WITH_GETLINE
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Also get a getline() prototype.

This makes the package to build on FreeBSD.