### PR TITLE
install udev rules

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,1 +1,4 @@
 SUBDIRS = src
+
+udevrulesdir = $(sysconfdir)/udev/rules.d
+dist_udevrules_DATA = etc/udev/rules.d/99-sc_hsm.rules


### PR DESCRIPTION
udev rules aren't installed per default which would be very useful