### PR TITLE
Fix C23 keyword conflicts with true/false

### DIFF
--- a/src/pkcs11/certificateobject.c
+++ b/src/pkcs11/certificateobject.c
@@ -540,20 +540,20 @@ int createCertificateObjectFromP15(struct p15CertificateDescription *p15, unsign
 {
 	CK_OBJECT_CLASS class = CKO_CERTIFICATE;
 	CK_CERTIFICATE_TYPE certType = CKC_X_509;
-	CK_BBOOL true = CK_TRUE;
-	CK_BBOOL false = CK_FALSE;
+	CK_BBOOL ck_true = CK_TRUE;
+	CK_BBOOL ck_false = CK_FALSE;
 	CK_ULONG category = 1;
 	CK_ATTRIBUTE template[] = {
 			{ CKA_CLASS, &class, sizeof(class) },
 			{ CKA_CERTIFICATE_TYPE, &certType, sizeof(certType) },
-			{ CKA_TRUSTED, &ckFalse, sizeof(false) },
+			{ CKA_TRUSTED, &ckFalse, sizeof(ck_false) },
 			{ CKA_CERTIFICATE_CATEGORY, &category, sizeof(category)},
-			{ CKA_TOKEN, &true, sizeof(true) },
-			{ CKA_PRIVATE, &false, sizeof(false) },
+			{ CKA_TOKEN, &ck_true, sizeof(ck_true) },
+			{ CKA_PRIVATE, &ck_false, sizeof(ck_false) },
 			{ CKA_LABEL, NULL, 0 },
 			{ CKA_ID, NULL, 0 },
 			{ CKA_VALUE, NULL, 0 },
-			{ CKA_MODIFIABLE, &false, sizeof(false) }
+			{ CKA_MODIFIABLE, &ck_false, sizeof(ck_false) }
 	};
 	struct p11Object_t *p11o;
 	unsigned char *po;
@@ -597,12 +597,12 @@ int createCertificateObjectFromP15(struct p15CertificateDescription *p15, unsign
 	}
 
 	if (p15->isCA) {
-		template[2].pValue = &true;
+		template[2].pValue = &ck_true;
 		category = 2;
 	}
 
 	if (p15->isModifiable) {
-		template[9].pValue = &true;
+		template[9].pValue = &ck_true;
 	}
 
 	p11o = calloc(sizeof(struct p11Object_t), 1);

--- a/src/pkcs11/privatekeyobject.c
+++ b/src/pkcs11/privatekeyobject.c
@@ -96,26 +96,26 @@ int createPrivateKeyObjectFromP15(struct p15PrivateKeyDescription *p15, struct p
 	CK_OBJECT_CLASS class = CKO_PRIVATE_KEY;
 	CK_KEY_TYPE keyType = CKK_RSA;
 	CK_MECHANISM_TYPE genMechType = CKM_RSA_PKCS_KEY_PAIR_GEN;
-	CK_BBOOL true = CK_TRUE;
-	CK_BBOOL false = CK_FALSE;
+	CK_BBOOL ck_true = CK_TRUE;
+	CK_BBOOL ck_false = CK_FALSE;
 	CK_ATTRIBUTE template[] = {
 			{ CKA_CLASS, &class, sizeof(class) },
 			{ CKA_KEY_TYPE, &keyType, sizeof(keyType) },
-			{ CKA_TOKEN, &true, sizeof(true) },
-			{ CKA_PRIVATE, &true, sizeof(true) },
+			{ CKA_TOKEN, &ck_true, sizeof(ck_true) },
+			{ CKA_PRIVATE, &ck_true, sizeof(ck_true) },
 			{ CKA_LABEL, NULL, 0 },
 			{ CKA_ID, NULL, 0 },
-			{ CKA_LOCAL, &true, sizeof(true) },
+			{ CKA_LOCAL, &ck_true, sizeof(ck_true) },
 			{ CKA_KEY_GEN_MECHANISM, &genMechType, sizeof(genMechType) },
-			{ CKA_SENSITIVE, &true, sizeof(true) },
-			{ CKA_DECRYPT, &true, sizeof(true) },
-			{ CKA_SIGN, &true, sizeof(true) },
-			{ CKA_SIGN_RECOVER, &true, sizeof(true) },
-			{ CKA_ALWAYS_AUTHENTICATE, &false, sizeof(false) },
-			{ CKA_UNWRAP, &false, sizeof(false) },
-			{ CKA_EXTRACTABLE, &false, sizeof(false) },
-			{ CKA_ALWAYS_SENSITIVE, &true, sizeof(true) },
-			{ CKA_NEVER_EXTRACTABLE, &true, sizeof(true) },
+			{ CKA_SENSITIVE, &ck_true, sizeof(ck_true) },
+			{ CKA_DECRYPT, &ck_true, sizeof(ck_true) },
+			{ CKA_SIGN, &ck_true, sizeof(ck_true) },
+			{ CKA_SIGN_RECOVER, &ck_true, sizeof(ck_true) },
+			{ CKA_ALWAYS_AUTHENTICATE, &ck_false, sizeof(ck_false) },
+			{ CKA_UNWRAP, &ck_false, sizeof(ck_false) },
+			{ CKA_EXTRACTABLE, &ck_false, sizeof(ck_false) },
+			{ CKA_ALWAYS_SENSITIVE, &ck_true, sizeof(ck_true) },
+			{ CKA_NEVER_EXTRACTABLE, &ck_true, sizeof(ck_true) },
 			{ 0, NULL, 0 },
 			{ 0, NULL, 0 }
 	};
@@ -149,10 +149,10 @@ int createPrivateKeyObjectFromP15(struct p15PrivateKeyDescription *p15, struct p
 		template[5].ulValueLen = (CK_ULONG)p15->id.len;
 	}
 
-	template[9].pValue = p15->usage & P15_DECIPHER ? &true : &false;
-	template[10].pValue = p15->usage & P15_SIGN ? &true : &false;
-	template[11].pValue = p15->usage & P15_SIGNRECOVER ? &true : &false;
-	template[12].pValue = useAA ? &true : &false;
+	template[9].pValue = p15->usage & P15_DECIPHER ? &ck_true : &ck_false;
+	template[10].pValue = p15->usage & P15_SIGN ? &ck_true : &ck_false;
+	template[11].pValue = p15->usage & P15_SIGNRECOVER ? &ck_true : &ck_false;
+	template[12].pValue = useAA ? &ck_true : &ck_false;
 
 	attributes = sizeof(template) / sizeof(CK_ATTRIBUTE) - 2;
 
@@ -202,27 +202,27 @@ int createPrivateKeyObjectFromP15AndPublicKey(struct p15PrivateKeyDescription *p
 	CK_OBJECT_CLASS class = CKO_PRIVATE_KEY;
 	CK_KEY_TYPE keyType = CKK_RSA;
 	CK_MECHANISM_TYPE genMechType = CKM_RSA_PKCS_KEY_PAIR_GEN;
-	CK_BBOOL true = CK_TRUE;
-	CK_BBOOL false = CK_FALSE;
+	CK_BBOOL ck_true = CK_TRUE;
+	CK_BBOOL ck_false = CK_FALSE;
 	struct p11Attribute_t *pattr;
 	CK_ATTRIBUTE template[] = {
 			{ CKA_CLASS, &class, sizeof(class) },
 			{ CKA_KEY_TYPE, &keyType, sizeof(keyType) },
-			{ CKA_TOKEN, &true, sizeof(true) },
-			{ CKA_PRIVATE, &true, sizeof(true) },
+			{ CKA_TOKEN, &ck_true, sizeof(ck_true) },
+			{ CKA_PRIVATE, &ck_true, sizeof(ck_true) },
 			{ CKA_LABEL, NULL, 0 },
 			{ CKA_ID, NULL, 0 },
-			{ CKA_LOCAL, &true, sizeof(true) },
+			{ CKA_LOCAL, &ck_true, sizeof(ck_true) },
 			{ CKA_KEY_GEN_MECHANISM, &genMechType, sizeof(genMechType) },
-			{ CKA_SENSITIVE, &true, sizeof(true) },
-			{ CKA_DECRYPT, &true, sizeof(true) },
-			{ CKA_SIGN, &true, sizeof(true) },
-			{ CKA_SIGN_RECOVER, &true, sizeof(true) },
-			{ CKA_ALWAYS_AUTHENTICATE, &false, sizeof(false) },
-			{ CKA_UNWRAP, &false, sizeof(false) },
-			{ CKA_EXTRACTABLE, &false, sizeof(false) },
-			{ CKA_ALWAYS_SENSITIVE, &true, sizeof(true) },
-			{ CKA_NEVER_EXTRACTABLE, &true, sizeof(true) },
+			{ CKA_SENSITIVE, &ck_true, sizeof(ck_true) },
+			{ CKA_DECRYPT, &ck_true, sizeof(ck_true) },
+			{ CKA_SIGN, &ck_true, sizeof(ck_true) },
+			{ CKA_SIGN_RECOVER, &ck_true, sizeof(ck_true) },
+			{ CKA_ALWAYS_AUTHENTICATE, &ck_false, sizeof(ck_false) },
+			{ CKA_UNWRAP, &ck_false, sizeof(ck_false) },
+			{ CKA_EXTRACTABLE, &ck_false, sizeof(ck_false) },
+			{ CKA_ALWAYS_SENSITIVE, &ck_true, sizeof(ck_true) },
+			{ CKA_NEVER_EXTRACTABLE, &ck_true, sizeof(ck_true) },
 			{ 0, NULL, 0 },
 			{ 0, NULL, 0 }
 	};
@@ -247,10 +247,10 @@ int createPrivateKeyObjectFromP15AndPublicKey(struct p15PrivateKeyDescription *p
 		template[5].ulValueLen = (CK_ULONG)p15->id.len;
 	}
 
-	template[9].pValue = p15->usage & P15_DECIPHER ? &true : &false;
-	template[10].pValue = p15->usage & P15_SIGN ? &true : &false;
-	template[11].pValue = p15->usage & P15_SIGNRECOVER ? &true : &false;
-	template[12].pValue = useAA ? &true : &false;
+	template[9].pValue = p15->usage & P15_DECIPHER ? &ck_true : &ck_false;
+	template[10].pValue = p15->usage & P15_SIGN ? &ck_true : &ck_false;
+	template[11].pValue = p15->usage & P15_SIGNRECOVER ? &ck_true : &ck_false;
+	template[12].pValue = useAA ? &ck_true : &ck_false;
 
 	attributes = sizeof(template) / sizeof(CK_ATTRIBUTE) - 2;
 

--- a/src/pkcs11/publickeyobject.c
+++ b/src/pkcs11/publickeyobject.c
@@ -106,22 +106,22 @@ int createPublicKeyObjectFromCertificate(struct p15PrivateKeyDescription *p15, s
 	CK_OBJECT_CLASS class = CKO_PUBLIC_KEY;
 	CK_KEY_TYPE keyType = CKK_RSA;
 	CK_UTF8CHAR label[10];
-	CK_BBOOL true = CK_TRUE;
-	CK_BBOOL false = CK_FALSE;
+	CK_BBOOL ck_true = CK_TRUE;
+	CK_BBOOL ck_false = CK_FALSE;
 	CK_ULONG modulus_bits = 2048;
 	CK_ATTRIBUTE template[] = {
 			{ CKA_CLASS, &class, sizeof(class) },
 			{ CKA_KEY_TYPE, &keyType, sizeof(keyType) },
-			{ CKA_TOKEN, &true, sizeof(true) },
-			{ CKA_PRIVATE, &false, sizeof(false) },
+			{ CKA_TOKEN, &ck_true, sizeof(ck_true) },
+			{ CKA_PRIVATE, &ck_false, sizeof(ck_false) },
 			{ CKA_LABEL, label, sizeof(label) - 1 },
 			{ CKA_ID, NULL, 0 },
-			{ CKA_LOCAL, &true, sizeof(true) },
-			{ CKA_ENCRYPT, &true, sizeof(true) },
-			{ CKA_VERIFY, &true, sizeof(true) },
-			{ CKA_VERIFY_RECOVER, &true, sizeof(true) },
-			{ CKA_WRAP, &false, sizeof(false) },
-			{ CKA_TRUSTED, &false, sizeof(false) },
+			{ CKA_LOCAL, &ck_true, sizeof(ck_true) },
+			{ CKA_ENCRYPT, &ck_true, sizeof(ck_true) },
+			{ CKA_VERIFY, &ck_true, sizeof(ck_true) },
+			{ CKA_VERIFY_RECOVER, &ck_true, sizeof(ck_true) },
+			{ CKA_WRAP, &ck_false, sizeof(ck_false) },
+			{ CKA_TRUSTED, &ck_false, sizeof(ck_false) },
 			{ 0, NULL, 0 },
 			{ 0, NULL, 0 },
 			{ 0, NULL, 0 }
@@ -213,22 +213,22 @@ int createPublicKeyObjectFromCVC(struct p15PrivateKeyDescription *p15, unsigned 
 {
 	CK_OBJECT_CLASS class = CKO_PUBLIC_KEY;
 	CK_KEY_TYPE keyType = CKK_RSA;
-	CK_BBOOL true = CK_TRUE;
-	CK_BBOOL false = CK_FALSE;
+	CK_BBOOL ck_true = CK_TRUE;
+	CK_BBOOL ck_false = CK_FALSE;
 	CK_ULONG modulus_bits;
 	CK_ATTRIBUTE template[] = {
 			{ CKA_CLASS, &class, sizeof(class) },
 			{ CKA_KEY_TYPE, &keyType, sizeof(keyType) },
-			{ CKA_TOKEN, &true, sizeof(true) },
-			{ CKA_PRIVATE, &false, sizeof(false) },
+			{ CKA_TOKEN, &ck_true, sizeof(ck_true) },
+			{ CKA_PRIVATE, &ck_false, sizeof(ck_false) },
 			{ CKA_LABEL, NULL, 0 },
 			{ CKA_ID, NULL, 0 },
-			{ CKA_LOCAL, &true, sizeof(true) },
-			{ CKA_ENCRYPT, &true, sizeof(true) },
-			{ CKA_VERIFY, &true, sizeof(true) },
-			{ CKA_VERIFY_RECOVER, &true, sizeof(true) },
-			{ CKA_WRAP, &false, sizeof(false) },
-			{ CKA_TRUSTED, &false, sizeof(false) },
+			{ CKA_LOCAL, &ck_true, sizeof(ck_true) },
+			{ CKA_ENCRYPT, &ck_true, sizeof(ck_true) },
+			{ CKA_VERIFY, &ck_true, sizeof(ck_true) },
+			{ CKA_VERIFY_RECOVER, &ck_true, sizeof(ck_true) },
+			{ CKA_WRAP, &ck_false, sizeof(ck_false) },
+			{ CKA_TRUSTED, &ck_false, sizeof(ck_false) },
 			{ CKA_CVC_REQUEST, NULL, 0 },
 			{ 0, NULL, 0 },
 			{ 0, NULL, 0 },

--- a/src/pkcs11/secretkeyobject.c
+++ b/src/pkcs11/secretkeyobject.c
@@ -95,29 +95,29 @@ int createSecretKeyObjectFromP15(struct p15SecretKeyDescription *p15, struct p11
 	CK_KEY_TYPE keyType = CKK_AES;
 	CK_MECHANISM_TYPE genMechType = CKM_AES_KEY_GEN;
 	CK_ULONG keylen = 0;
-	CK_BBOOL true = CK_TRUE;
-	CK_BBOOL false = CK_FALSE;
+	CK_BBOOL ck_true = CK_TRUE;
+	CK_BBOOL ck_false = CK_FALSE;
 	CK_ATTRIBUTE template[] = {
 			{ CKA_CLASS, &class, sizeof(class) },
 			{ CKA_KEY_TYPE, &keyType, sizeof(keyType) },
-			{ CKA_TOKEN, &true, sizeof(true) },
-			{ CKA_PRIVATE, &true, sizeof(true) },
+			{ CKA_TOKEN, &ck_true, sizeof(ck_true) },
+			{ CKA_PRIVATE, &ck_true, sizeof(ck_true) },
 			{ CKA_LABEL, NULL, 0 },
 			{ CKA_ID, NULL, 0 },
-			{ CKA_LOCAL, &true, sizeof(true) },
+			{ CKA_LOCAL, &ck_true, sizeof(ck_true) },
 			{ CKA_KEY_GEN_MECHANISM, &genMechType, sizeof(genMechType) },
 			{ CKA_VALUE_LEN, &keylen, sizeof(keylen) },
-			{ CKA_SENSITIVE, &true, sizeof(true) },
-			{ CKA_ENCRYPT, &true, sizeof(true) },
-			{ CKA_DECRYPT, &true, sizeof(true) },
-			{ CKA_SIGN, &true, sizeof(true) },
-			{ CKA_VERIFY, &true, sizeof(true) },
-			{ CKA_WRAP, &false, sizeof(false) },
-			{ CKA_UNWRAP, &false, sizeof(false) },
-			{ CKA_DERIVE, &false, sizeof(false) },
-			{ CKA_EXTRACTABLE, &false, sizeof(false) },
-			{ CKA_ALWAYS_SENSITIVE, &true, sizeof(true) },
-			{ CKA_NEVER_EXTRACTABLE, &true, sizeof(true) }
+			{ CKA_SENSITIVE, &ck_true, sizeof(ck_true) },
+			{ CKA_ENCRYPT, &ck_true, sizeof(ck_true) },
+			{ CKA_DECRYPT, &ck_true, sizeof(ck_true) },
+			{ CKA_SIGN, &ck_true, sizeof(ck_true) },
+			{ CKA_VERIFY, &ck_true, sizeof(ck_true) },
+			{ CKA_WRAP, &ck_false, sizeof(ck_false) },
+			{ CKA_UNWRAP, &ck_false, sizeof(ck_false) },
+			{ CKA_DERIVE, &ck_false, sizeof(ck_false) },
+			{ CKA_EXTRACTABLE, &ck_false, sizeof(ck_false) },
+			{ CKA_ALWAYS_SENSITIVE, &ck_true, sizeof(ck_true) },
+			{ CKA_NEVER_EXTRACTABLE, &ck_true, sizeof(ck_true) }
 	};
 	struct p11Object_t *p11o;
 	int rc, attributes;
@@ -142,13 +142,13 @@ int createSecretKeyObjectFromP15(struct p15SecretKeyDescription *p15, struct p11
 
 	keylen = p15->keysize >> 3;
 
-	template[10].pValue = p15->usage & P15_ENCIPHER ? &true : &false;
-	template[11].pValue = p15->usage & P15_DECIPHER ? &true : &false;
-	template[12].pValue = p15->usage & P15_SIGN ? &true : &false;
-	template[13].pValue = p15->usage & P15_VERIFY ? &true : &false;
-	template[14].pValue = p15->usage & P15_KEYENCIPHER ? &true : &false;
-	template[15].pValue = p15->usage & P15_KEYDECIPHER ? &true : &false;
-	template[16].pValue = p15->usage & P15_DERIVE ? &true : &false;
+	template[10].pValue = p15->usage & P15_ENCIPHER ? &ck_true : &ck_false;
+	template[11].pValue = p15->usage & P15_DECIPHER ? &ck_true : &ck_false;
+	template[12].pValue = p15->usage & P15_SIGN ? &ck_true : &ck_false;
+	template[13].pValue = p15->usage & P15_VERIFY ? &ck_true : &ck_false;
+	template[14].pValue = p15->usage & P15_KEYENCIPHER ? &ck_true : &ck_false;
+	template[15].pValue = p15->usage & P15_KEYDECIPHER ? &ck_true : &ck_false;
+	template[16].pValue = p15->usage & P15_DERIVE ? &ck_true : &ck_false;
 
 	attributes = sizeof(template) / sizeof(CK_ATTRIBUTE);
 


### PR DESCRIPTION
## Problem

GCC 15+ (and Clang 19+) enable C23 by default, where `true` and `false` are reserved keywords. This causes compilation errors in four PKCS#11 object files that use `true`/`false` as local `CK_BBOOL` variable names:

```
error: expected identifier or '(' before 'true'
   96 |  CK_BBOOL true = CK_TRUE;
      |           ^~~~
```

## Fix

Rename local variables in the affected files:
- `true` → `ck_true`
- `false` → `ck_false`

### Affected files
- `src/pkcs11/certificateobject.c`
- `src/pkcs11/privatekeyobject.c`
- `src/pkcs11/publickeyobject.c`
- `src/pkcs11/secretkeyobject.c`

## Impact

No behavioral change — only local variable names are renamed. The assigned values (`CK_TRUE`/`CK_FALSE`) and all references remain identical.

Tested with GCC 15.0.1 on Arch Linux.